### PR TITLE
CARGO_PLAYGROUND_DIR & clean

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,7 @@ name = "cargo-playground"
 version = "0.1.0"
 dependencies = [
  "ansi_term",
+ "regex",
  "structopt",
  "watchexec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ structopt = "0.3"
 watchexec = "1.14.1"
 # FIXME: upgrade to latest version when clap 3 comes out of beta
 ansi_term = "0.11" # Old version, but this is used by clap 2.33
+regex = "1.4.5"

--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ It has the following options and flags:
 
 This lists all the playgrounds.
 
+#### `cargo playground clean`
+
+Deletes the Cargo projects in the playground directory.
+
+It has the following options:
+```
+ -m, --matches <matches> A regex to match against playground names. If
+                         not given all will be deleted.
+```
+
 ## Support
 
 - Terminal based editor + tmux: It opens a pane to the right which has

--- a/README.md
+++ b/README.md
@@ -34,9 +34,20 @@ $ cargo playground ls
 $ cargo playground open -e vim -a=-o2 test-playground
 ```
 
+#### Environment variables
+
+The following environment variables are used:
+
+- `VISUAL`: The editor in which to open the playground. It is required
+  unless --editor is given
+
+- `CARGO_PLAYGROUND_DIR`: The path to the directory which is used for
+  creating playgrounds. If not set, the temp directory is used. eg: in
+  unix: `/tmp/cargo-playground/`
+
 #### `cargo playground new`
 
-This creates and opens a new playground in the `/tmp/cargo-playground/<name>`
+This creates and opens a new playground.
 
 It has the following options and flags:
 ```

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -1,0 +1,58 @@
+use crate::error;
+use std::fs;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub struct CleanOpts {
+    /// A regex to match against playground names. If not provided, all will be deleted.
+    #[structopt(long, short)]
+    matches: Option<String>,
+}
+
+pub fn clean(opts: CleanOpts) -> error::Result<()> {
+    let path = super::get_dir();
+
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let regex = match opts.matches {
+        Some(matches) => {
+            let regex = regex::RegexBuilder::new(&matches)
+                .case_insensitive(true)
+                .build()
+                .map_err(|err| error::Error::new(std::io::ErrorKind::InvalidInput, err))?;
+            Some(regex)
+        }
+        None => None,
+    };
+
+    // ignoring errors for now, maybe do something about it?
+    for entry in path.read_dir()?.filter_map(Result::ok) {
+        let mut path = entry.path();
+
+        match (&regex, path.file_name().unwrap().to_str()) {
+            (None, _) => {}
+            (Some(regex), Some(path)) if regex.is_match(path) => {}
+            _ => continue,
+        }
+
+        path.push("Cargo.toml");
+
+        if path.exists() {
+            path.pop();
+
+            if let Err(io_err) = fs::remove_dir_all(&path) {
+                let err = error::Error::new(
+                    io_err.kind(),
+                    format!("couldn't delete playground at {:?}: {}", path, io_err),
+                )
+                .with_help("check if the right directory is being cleaned");
+
+                eprintln!("{}", err);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
+mod clean;
 mod error;
 mod new;
 mod open;
@@ -30,6 +31,8 @@ enum PlaygroundOpts {
     // Override the default because it include '--editor <editor>'
     #[structopt(usage = "cargo playground open [FLAGS] [OPTIONS] <name>")]
     Open(open::OpenOpts),
+    /// Cleans the playgrounds directory, deleting all cargo projects in it.
+    Clean(clean::CleanOpts),
     /// List currently existing playgrounds
     #[structopt(alias = "list")]
     Ls,
@@ -74,12 +77,9 @@ fn run() -> error::Result<()> {
     };
 
     match opts {
-        PlaygroundOpts::New(opts) => {
-            new::new(opts)?;
-        }
-        PlaygroundOpts::Open(opts) => {
-            open::open(opts)?;
-        }
+        PlaygroundOpts::New(opts) => new::new(opts),
+        PlaygroundOpts::Open(opts) => open::open(opts),
+        PlaygroundOpts::Clean(opts) => clean::clean(opts),
         PlaygroundOpts::Ls => {
             let path = get_dir();
             if !path.exists() {
@@ -94,8 +94,8 @@ fn run() -> error::Result<()> {
                     }
                 }
             }
+
+            Ok(())
         }
     }
-
-    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,9 @@ struct EditorOpts {
 }
 
 fn get_dir() -> PathBuf {
-    env::temp_dir().join("cargo-playground")
+    env::var_os("CARGO_PLAYGROUND_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| env::temp_dir().join("cargo-playground"))
 }
 
 fn main() {


### PR DESCRIPTION
Use CARGO_PLAYGROUND_DIR if set to determine where the playground is
made. If not set, it will default to the temp directory.

Also added a clean command, to delete all Cargo projects in a directory,
optionally matching on some regex.

Fixes #3 
